### PR TITLE
Fix parse in cookies

### DIFF
--- a/aws_log_parser/parser.py
+++ b/aws_log_parser/parser.py
@@ -48,7 +48,13 @@ def to_http_request(value):
 def to_cookie(value):
     cookie = cookies.SimpleCookie()
     cookie.load(rawdata=value)
-    return cookie
+    
+    cookiedict = {}
+
+    for key, morsel in cookie.items():
+        cookiedict[key.replace('%20', '')] = morsel.value
+
+    return cookiedict
 
 
 def to_python(value, field):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,14 +12,24 @@ def log_entry(entry):
 def cookie_zip_code():
     cookie = cookies.SimpleCookie()
     cookie.load(rawdata='zip=98101')
-    return cookie
+    cookiedict = {}
+
+    for key, morsel in cookie.items():
+        cookiedict[key.replace('%20', '')] = morsel.value
+
+    return cookiedict
 
 
 @pytest.fixture
 def cookie_empty():
     cookie = cookies.SimpleCookie()
     cookie.load(rawdata='')
-    return cookie
+    cookiedict = {}
+
+    for key, morsel in cookie.items():
+        cookiedict[key.replace('%20', '')] = morsel.value
+
+    return cookiedict
 
 
 @pytest.fixture


### PR DESCRIPTION
The parse for the cookies was bad. Only its parsed the **name of the cookie** + **morsel objects** (_expire, path, comment..._) without value. 

With this fix, now parsed the name of the cookie and its value.  Also, replace %20 (space in url encode) in the name of the cookie.
Tests have been passed correctly.