### PR TITLE
Adding support for gzipped ALB logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ The general method to read files is `read_url`. It returns a generator of
 dataclasses for the specified `LogType`. Currently the S3 and file
 schemes are supported.
 
+GZipped LoadBalancer logs are supported by passing `file_suffix=".gz"` to
+the AwsLogParser initilizer.
+
 S3:
 
 ```python

--- a/aws_log_parser/aws/s3.py
+++ b/aws_log_parser/aws/s3.py
@@ -31,12 +31,12 @@ class S3Service(AwsService):
     def read_key(self, bucket, key, endswith=None):
         if self.aws_client.verbose:
             print(f"Reading s3://{bucket}/{key}")
-        object = self.client.get_object(Bucket=bucket, Key=key)
+        contents = self.client.get_object(Bucket=bucket, Key=key)
         if endswith == ".gz":
-            with gzip.GzipFile(fileobj=object["Body"]) as _gz:
+            with gzip.GzipFile(fileobj=contents["Body"]) as _gz:
                 yield from [line for line in _gz.read().decode("utf-8").splitlines()]
         else:
-            yield from [line.decode("utf-8") for line in object["Body"].iter_lines()]
+            yield from [line.decode("utf-8") for line in contents["Body"].iter_lines()]
         
 
     def read_keys(self, bucket, prefix, endswith=None):

--- a/aws_log_parser/aws/s3.py
+++ b/aws_log_parser/aws/s3.py
@@ -1,3 +1,5 @@
+import gzip
+
 from dataclasses import dataclass
 
 from .client import (
@@ -26,11 +28,16 @@ class S3Service(AwsService):
 
         return sorted(items, key=lambda x: x[sort_key], reverse=reverse)
 
-    def read_key(self, bucket, key):
+    def read_key(self, bucket, key, endswith=None):
         if self.aws_client.verbose:
             print(f"Reading s3://{bucket}/{key}")
-        contents = self.client.get_object(Bucket=bucket, Key=key)
-        yield from [line.decode("utf-8") for line in contents["Body"].iter_lines()]
+        object = self.client.get_object(Bucket=bucket, Key=key)
+        if endswith == ".gz":
+            with gzip.GzipFile(fileobj=object["Body"]) as _gz:
+                yield from [line for line in _gz.read().decode("utf-8").splitlines()]
+        else:
+            yield from [line.decode("utf-8") for line in object["Body"].iter_lines()]
+        
 
     def read_keys(self, bucket, prefix, endswith=None):
 
@@ -38,4 +45,4 @@ class S3Service(AwsService):
             if endswith and not file["Key"].endswith(endswith):
                 continue
 
-            yield from self.read_key(bucket, file["Key"])
+            yield from self.read_key(bucket, file["Key"], endswith)

--- a/examples/count-hosts-gzip-alb.py
+++ b/examples/count-hosts-gzip-alb.py
@@ -1,0 +1,53 @@
+#!/bin/env python
+
+import argparse
+
+from collections import Counter
+from operator import attrgetter
+
+from aws_log_parser import AwsLogParser, LogType
+
+
+def count_ips(entries, ip_attr):
+
+    counter = Counter(attrgetter(ip_attr)(entry) for entry in entries)
+
+    for ip, count in sorted(counter.items()):
+        print(f"{ip}: {count}")
+
+
+def main():
+    """
+    python examples/count-hosts-gzip-alb.py \
+        s3://aws-logs-test-data/test-alb/AWSLogs/111111111111/elasticloadbalancing/us-east-1/2022/01/01
+    """
+
+    parser = argparse.ArgumentParser(description="Parse AWS log data.")
+    parser.add_argument(
+        "url",
+        help="Url to the file to parse",
+    )
+
+    parser.add_argument(
+        "--profile",
+        help="The aws profile to use.",
+    )
+
+    parser.add_argument(
+        "--region",
+        help="The aws region to use.",
+    )
+
+    args = parser.parse_args()
+
+    entries = AwsLogParser(
+        log_type=LogType.LoadBalancer,
+        profile=args.profile,
+        region=args.region,
+        file_suffix=".gz"
+    ).read_url(args.url)
+
+    count_ips(entries, "client.ip")
+
+
+main()


### PR DESCRIPTION
This PR adds the ability to parse gzipped LoadBalancer logs.  It is common for AWS to compress the ALB logs these days.

I've attempted to maintain as much of the efficiency of the original iterative reading code, but it is somewhat challenging when needing to decompress the contents of the blob before parsing it. 