### PR TITLE
HOTFIX: Loading json logs

### DIFF
--- a/aws_log_parser/interface.py
+++ b/aws_log_parser/interface.py
@@ -75,7 +75,7 @@ class AwsLogParser:
 
     def parse_json(self, records):
         for record in records:
-            yield self.log_type.model.from_dict(record)  # type: ignore
+            yield self.log_type.model.from_json(record)  # type: ignore
 
     def parse(self, content):
         parse_func = (


### PR DESCRIPTION
Just tried it on real WAF logs coming from s3 and I believe this fix is needed to make it work.

Without it, I'm getting:

```
#10 2.147   File "/var/task/aws_log_parser/interface.py", line 165, in read_url
#10 2.147     yield from self.read_s3(
#10 2.147   File "/var/task/aws_log_parser/interface.py", line 135, in read_s3
#10 2.147     yield from self.parse(
#10 2.147   File "/var/task/aws_log_parser/interface.py", line 89, in parse
#10 2.147     yield from log_entries
#10 2.147   File "/var/task/aws_log_parser/interface.py", line 78, in parse_json
#10 2.147     yield self.log_type.model.from_dict(record)  # type: ignore
#10 2.147   File "/var/task/dataclasses_json/api.py", line 72, in from_dict
#10 2.147     return _decode_dataclass(cls, kvs, infer_missing)
#10 2.147   File "/var/task/dataclasses_json/core.py", line 137, in _decode_dataclass
#10 2.147     kvs = {decode_names.get(k, k): v for k, v in kvs.items()}
#10 2.147 AttributeError: 'str' object has no attribute 'items'
```

